### PR TITLE
only selects SYSTEM tokens without Process Protection

### DIFF
--- a/SharpImpersonation/Resources/Constants.cs
+++ b/SharpImpersonation/Resources/Constants.cs
@@ -510,6 +510,11 @@ namespace SharpImpersonation
         public _LUID ModifiedId;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct _PROCESS_PROTECTION_LEVEL_INFORMATION
+    {
+        public DWORD ProtectionLevel;
+    }
 
     [StructLayout(LayoutKind.Sequential)]
     public struct _PRIVILEGE_SET
@@ -564,6 +569,22 @@ namespace SharpImpersonation
         TokenSecurityAttributes,
         TokenIsRestricted,
         MaxTokenInfoClass
+    }
+
+    [Flags]
+    public enum _PROCESS_INFORMATION_CLASS
+    {
+        ProcessMemoryPriority,
+        ProcessMemoryExhaustionInfo,
+        ProcessAppMemoryInfo,
+        ProcessInPrivateInfo,
+        ProcessPowerThrottling,
+        ProcessReservedValue1,
+        ProcessTelemetryCoverageInfo,
+        ProcessProtectionLevelInfo,
+        ProcessLeapSecondInfo,
+        ProcessMachineTypeInfo,
+        ProcessInformationClassMax
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/SharpImpersonation/Unmanaged.cs
+++ b/SharpImpersonation/Unmanaged.cs
@@ -5,6 +5,8 @@ using System.Text;
 
 namespace SharpImpersonation
 {
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    delegate Boolean GetProcessInformation(IntPtr hProcess, _PROCESS_INFORMATION_CLASS processInformationClass, ref _PROCESS_PROTECTION_LEVEL_INFORMATION processInformation, uint processInformationSize);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     delegate Boolean OpenProcessToken(IntPtr hProcess, UInt32 dwDesiredAccess, out IntPtr hToken);


### PR DESCRIPTION
Iterates through the first SYSTEM Token to see if it does NOT have a Process Protection (0xFFFFFFFE). If so, it adds it to the users dictionary. If not (aka - if it does have protection), then it continues until it finds one without process protection.